### PR TITLE
Fixed missing response parameter in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ class TodosService extends HttpServiceBase {
 
     return getQuery(
       request: request,
-      mapper: (json) => TodosResponse.fromJson(json),
+      mapper: (json, _) => TodosResponse.fromJson(json),
     );
   }
 }


### PR DESCRIPTION
The mapper function in TodosService was missing the second parameter causing a compile error if put in a .dart file
because `T Function(Map<String, dynamic>)` did not match the mapper signature of `T Function(Map<String, dynamic>, Response response)`

Fixed by adding a _ placeholder for the Response parameter.